### PR TITLE
Fix <=> for IPv4 and IPv6.

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -509,6 +509,7 @@ module IPAddress;
     #     #=> ["10.100.100.1/8","10.100.100.1/16","172.16.0.1/16"]
     #
     def <=>(oth)
+      return nil unless oth.is_a?(self.class)
       return prefix <=> oth.prefix if to_u32 == oth.to_u32  
       to_u32 <=> oth.to_u32
     end

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -487,6 +487,7 @@ module IPAddress;
     #     #=> ["2001:db8:1::1/64","2001:db8:1::1/65","2001:db8:2::1/64"]
     #
     def <=>(oth)
+      return nil unless oth.is_a?(self.class)
       return prefix <=> oth.prefix if to_u128 == oth.to_u128  
       to_u128 <=> oth.to_u128
     end

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -372,6 +372,12 @@ class IPv4Test < Minitest::Test
     ip3 = @klass.new("10.0.0.0/8")
     arr = ["10.0.0.0/8","10.0.0.0/16","10.0.0.0/24"]
     assert_equal arr, [ip1,ip2,ip3].sort.map{|s| s.to_string}
+    # compare with alien thing
+    ip1 = @klass.new('127.0.0.1')
+    ip2 = IPAddress::IPv6.new('::1')
+    not_ip = String
+    assert_equal nil, ip1 <=> ip2
+    assert_equal nil, ip1 <=> not_ip
   end
 
   def test_method_minus

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -254,6 +254,12 @@ class IPv6Test < Minitest::Test
     arr = ["2001:db8:1::1/64","2001:db8:1::1/65",
            "2001:db8:1::2/64","2001:db8:2::1/64"]
     assert_equal arr, [ip1,ip2,ip3,ip4].sort.map{|s| s.to_string}
+    # compare with alien thing
+    ip1 = @klass.new('::1')
+    ip2 = IPAddress::IPv4.new('127.0.0.1')
+    not_ip = String
+    assert_equal nil, ip1 <=> ip2
+    assert_equal nil, ip1 <=> not_ip
   end
 
   def test_classmethod_expand


### PR DESCRIPTION
Comparing `IPAddress::IPv4` or `IPAddress::IPv6` instances against another class currently raises an exception…  Returning `nil` is more appropriate since `"42" <=> 42 #=> nil`.
